### PR TITLE
Fix reconnect bug

### DIFF
--- a/app/src/main/java/com/DnD5eTools/ui/CombatTracker.java
+++ b/app/src/main/java/com/DnD5eTools/ui/CombatTracker.java
@@ -119,7 +119,7 @@ public class CombatTracker extends Fragment {
             final AlertDialog.Builder connectionDialog = new AlertDialog.Builder(getContext());
             connectionDialog.setView(checkConn);
             connectionDialog.setTitle("Connection Error");
-            connectionDialog.setCancelable(false);
+            connectionDialog.setCancelable(true);
             connectionDialog.setPositiveButton("Change Connection", null);
             connectionDialog.setNegativeButton("Retry", null);
 
@@ -142,6 +142,7 @@ public class CombatTracker extends Fragment {
                 @Override
                 public void onDismiss(DialogInterface dialog) {
                     refresh();
+                    System.out.println("dismissed");
                 }
             });
 
@@ -179,7 +180,7 @@ public class CombatTracker extends Fragment {
     }
 
     public void refresh() {
-        CombatTracker tracker = this;
+        Fragment tracker = this;
         getFragmentManager().findFragmentById(tracker.getId());
 
         getFragmentManager().beginTransaction()
@@ -187,7 +188,7 @@ public class CombatTracker extends Fragment {
                 .attach(tracker)
                 .commit();
 
-        onCreateView(inflater, container, savedInstanceState);
+        //onCreateView(inflater, container, null);
 
         //update other two fragments
         MonsterBuilder.getMonBuilder().refresh();

--- a/app/src/main/java/com/DnD5eTools/ui/EncounterBuilder.java
+++ b/app/src/main/java/com/DnD5eTools/ui/EncounterBuilder.java
@@ -67,11 +67,11 @@ public class EncounterBuilder extends Fragment {
         this.savedInstanceState = savedInstanceState;
         builder = this;
 
-        view = inflater.inflate(R.layout.encounter_builder_layout, container, false);
-        view.setId(View.generateViewId());
-        view.setTag("EncounterBuilder");
-
         if (MainActivity.isConnected()) {
+            view = inflater.inflate(R.layout.encounter_builder_layout, container, false);
+            view.setId(View.generateViewId());
+            view.setTag("EncounterBuilder");
+
             playerLevelsContainer = view.findViewById(R.id.encounter_player_levels_container);
             monstersContainer = view.findViewById(R.id.encounter_monsters_container);
 

--- a/app/src/main/java/com/DnD5eTools/ui/MainActivity.java
+++ b/app/src/main/java/com/DnD5eTools/ui/MainActivity.java
@@ -67,8 +67,8 @@ public class MainActivity extends AppCompatActivity {
         //TODO: cannot write to assets. Current solution for changing server works, but settings cannot be saved; find solution
         //for Rpi: 192.168.1.110, 8000
         //for pc: 192.168.1.118, 8000
+        //chris's house: 192.168.0.24 (I think?), 8000
         proxy = new DNDClientProxy(host, port);
-        checkConnection();
     }
 
     private static void checkConnection() {
@@ -93,6 +93,7 @@ public class MainActivity extends AppCompatActivity {
     }
 
     public static boolean isConnected() {
+        checkConnection();
         System.out.println("connected: " + connection[0]);
         return connection[0];
     }
@@ -103,16 +104,6 @@ public class MainActivity extends AppCompatActivity {
 
     public static void updateProxy(String host, int port) {
         proxy.changeConnection(host, port);
-        checkConnection();
-        //updateActivities();
-    }
-
-    public static void updateActivities() {
-        //CombatTracker tracker = new CombatTracker();
-        MonsterBuilder monBuilder = new MonsterBuilder();
-        CombatTracker ct = (CombatTracker) fm.findFragmentByTag("CombatTracker");
-        //ct.refresh();
-        //ct.onCreateView(ct.getLayoutInflater(), )
     }
 
     @Override

--- a/app/src/main/java/com/DnD5eTools/ui/MonsterBuilder.java
+++ b/app/src/main/java/com/DnD5eTools/ui/MonsterBuilder.java
@@ -109,12 +109,12 @@ public class MonsterBuilder extends Fragment {
         this.savedInstanceState = savedInstanceState;
         builder = this;
 
-        proxy = MainActivity.getProxy();
-        view = inflater.inflate(R.layout.monster_builder_layout, container, false);
-        view.setId(View.generateViewId());
-        view.setTag("MonsterBuilder");
-
         if (MainActivity.isConnected()) {
+            proxy = MainActivity.getProxy();
+            view = inflater.inflate(R.layout.monster_builder_layout, container, false);
+            view.setId(View.generateViewId());
+            view.setTag("MonsterBuilder");
+
             abilities = view.findViewById(R.id.monster_abilities_layout);
             actions = view.findViewById(R.id.monster_actions_layout);
             legActions = view.findViewById(R.id.monster_legendary_actions_layout);


### PR DESCRIPTION
Previous changes somehow caused a bug where if the app failed to connect on boot, the reconnection alert dialog would hang, even after successfully reconnecting and loading all fragments. This bug has been fixed